### PR TITLE
Fix icon rendering as all black when color opts aren't provided

### DIFF
--- a/blockies.js
+++ b/blockies.js
@@ -79,6 +79,7 @@
 	}
 
 	function renderIcon(opts, canvas) {
+		opts = buildOpts(opts || {});
 		var imageData = createImageData(opts.size);
 		var width = Math.sqrt(imageData.length);
 
@@ -106,7 +107,6 @@
 	}
 
 	function createIcon(opts) {
-		var opts = buildOpts(opts || {});
 		var canvas = document.createElement('canvas');
 
 		renderIcon(opts, canvas);


### PR DESCRIPTION
If color options aren't provided, the defaults aren't assigned on the first invocation of createIcon, resulting in a completely black icon. This is caused by storing the result of buildOpts in a new var that shadows the original param. Additionally, if renderIcon is used externally, buildOpts is never called, defaults aren't assigned, and the randseed isn't generated.

This PR fixes the aforementioned issues.